### PR TITLE
simpler/more efficient interleaving for up_conv

### DIFF
--- a/tensorflow/models/network.py
+++ b/tensorflow/models/network.py
@@ -11,6 +11,24 @@ import tensorflow as tf
 
 DEFAULT_PADDING = 'SAME'
 
+
+def get_incoming_shape(incoming):
+    """ Returns the incoming data shape """
+    if isinstance(incoming, tf.Tensor):
+        return incoming.get_shape().as_list()
+    elif type(incoming) in [np.array, list, tuple]:
+        return np.shape(incoming)
+    else:
+        raise Exception("Invalid incoming layer.")
+
+
+def interleave(tensors, axis):
+    old_shape = get_incoming_shape(tensors[0])[1:]
+    new_shape = [-1] + old_shape
+    new_shape[axis] *= len(tensors)
+    return tf.reshape(tf.pack(tensors, axis + 1), new_shape)
+
+
 def layer(op):
     '''Decorator for composable network layers.'''
 
@@ -294,7 +312,7 @@ class Network(object):
         # --------------------------------------------------
         layerName = "layer%s_ConvA" % (id)
         self.feed(input_data)
-        self.conv( 3, 3, size[3], stride, stride, name = layerName, padding = 'SAME', relu = False)
+        self.conv(3, 3, size[3], stride, stride, name = layerName, padding = 'SAME', relu = False)
         outputA = self.get_output()
 
         # Convolution B (2x3)
@@ -323,34 +341,9 @@ class Network(object):
 
         # Interleaving elements of the four feature maps
         # --------------------------------------------------
-        dims = outputA.get_shape()
-        dim1 = dims[1] * 2
-        dim2 = dims[2] * 2
-
-        A_row_indices = range(0, dim1, 2)
-        A_col_indices = range(0, dim2, 2)
-        B_row_indices = range(1, dim1, 2)
-        B_col_indices = range(0, dim2, 2)
-        C_row_indices = range(0, dim1, 2)
-        C_col_indices = range(1, dim2, 2)
-        D_row_indices = range(1, dim1, 2)
-        D_col_indices = range(1, dim2, 2)
-
-        all_indices_before = range(int(self.batch_size))
-        all_indices_after = range(dims[3])
-
-        A_linear_indices = self.prepare_indices(all_indices_before, A_row_indices, A_col_indices, all_indices_after, dims)
-        B_linear_indices = self.prepare_indices(all_indices_before, B_row_indices, B_col_indices, all_indices_after, dims) 
-        C_linear_indices = self.prepare_indices(all_indices_before, C_row_indices, C_col_indices, all_indices_after, dims)
-        D_linear_indices = self.prepare_indices(all_indices_before, D_row_indices, D_col_indices, all_indices_after, dims)
-
-        A_flat = tf.reshape(tf.transpose(outputA, [1, 0, 2, 3]), [-1])
-        B_flat = tf.reshape(tf.transpose(outputB, [1, 0, 2, 3]), [-1])
-        C_flat = tf.reshape(tf.transpose(outputC, [1, 0, 2, 3]), [-1])
-        D_flat = tf.reshape(tf.transpose(outputD, [1, 0, 2, 3]), [-1])
-
-        Y_flat = tf.dynamic_stitch([A_linear_indices, B_linear_indices, C_linear_indices, D_linear_indices], [A_flat, B_flat, C_flat, D_flat])
-        Y = tf.reshape(Y_flat, shape = tf.to_int32([-1, dim1.value, dim2.value, dims[3].value]))
+        left = interleave([outputA, outputB], axis=1)  # columns
+        right = interleave([outputC, outputD], axis=1)  # columns
+        Y = interleave([left, right], axis=2)  # rows
         
         if BN:
             layerName = "layer%s_BN" % (id)

--- a/tensorflow/models/network.py
+++ b/tensorflow/models/network.py
@@ -341,9 +341,9 @@ class Network(object):
 
         # Interleaving elements of the four feature maps
         # --------------------------------------------------
-        left = interleave([outputA, outputB], axis=1)  # columns
-        right = interleave([outputC, outputD], axis=1)  # columns
-        Y = interleave([left, right], axis=2)  # rows
+        left = interleave([outputA, outputB], axis=1)  # interleave A and B along height axis
+        right = interleave([outputC, outputD], axis=1)  # interleave C and D along height axis
+        Y = interleave([left, right], axis=2)  # interleave result along width axis
         
         if BN:
             layerName = "layer%s_BN" % (id)

--- a/tensorflow/predict.py
+++ b/tensorflow/predict.py
@@ -4,11 +4,20 @@ import numpy as np
 import tensorflow as tf
 from matplotlib import pyplot as plt
 from PIL import Image
+from datetime import datetime
 
 import models
 
-def predict(model_data_path, image_path):
 
+def timer(fn, *args, **kwargs):
+    start = datetime.utcnow()
+    result = fn(*args, **kwargs)
+    finish = datetime.utcnow()
+    print('Elapsed time for', fn.__name__ + ':', finish - start)
+    return result
+
+
+def predict(model_data_path, image_path):
     # Default input size
     height = 228
     width = 304
@@ -44,12 +53,15 @@ def predict(model_data_path, image_path):
         sess.run(init_new_vars_op)
         
         # Evalute the network for the given image
-        pred = sess.run(net.get_output(), feed_dict={input_node: img})
+        pred = timer(sess.run, net.get_output(), feed_dict={input_node: img})
         
         # Plot result
         fig = plt.figure()
-        ii = plt.imshow(pred[0,:,:,0], interpolation='nearest')
-        fig.colorbar(ii)
+        fig.add_subplot(1, 2, 1)
+        plt.imshow(img[0,:,:,:])
+        fig.add_subplot(1, 2, 2)
+        ii = plt.imshow(pred[0,:,:,0], interpolation='nearest', cmap='Spectral')
+        plt.colorbar(ii)
         plt.show()
 
         return pred


### PR DESCRIPTION
time comparison on a single image (inference):
Elapsed time for run: 0:00:02.076628 (pack + reshape)
Elapsed time for run: 0:00:02.555231 (dynamic stitch)

disclaimers:
* I ran on a CPU instead of a GPU, so it's probably worth testing that.
* I included the timing code so you guys know what I did to time it (just wrapped the session.run)
* I included a get_incoming_shape since I just felt like lists with integers are easier to deal with than tensorflow's Dimension stuff.
* Also added code to display the input image. Thought it would be nice to compare.